### PR TITLE
Add diagnostic for missing MV targets in Kafka

### DIFF
--- a/src/Storages/Kafka/StorageKafka.cpp
+++ b/src/Storages/Kafka/StorageKafka.cpp
@@ -571,8 +571,13 @@ void StorageKafka::threadFunc(size_t idx)
             // Keep streaming as long as there are attached views and streaming is not cancelled
             while (!task->stream_cancelled)
             {
-                if (!StorageKafkaUtils::checkDependencies(table_id, getContext()))
+                if (auto err = StorageKafkaUtils::checkDependencies(table_id, getContext()))
+                {
+                    auto safe_consumers = getSafeConsumers();
+                    for (auto const & consumer_ptr : safe_consumers.consumers)
+                        consumer_ptr->setExceptionInfo(*err, false);
                     break;
+                }
 
                 LOG_DEBUG(log, "Started streaming to {} attached views", num_views);
 

--- a/src/Storages/Kafka/StorageKafka2.cpp
+++ b/src/Storages/Kafka/StorageKafka2.cpp
@@ -1192,8 +1192,13 @@ void StorageKafka2::threadFunc(size_t idx)
             while (!task->stream_cancelled && num_created_consumers > 0)
             {
                 maybe_stall_reason.reset();
-                if (!StorageKafkaUtils::checkDependencies(table_id, getContext()))
+                if (auto err = StorageKafkaUtils::checkDependencies(table_id, getContext()))
+                {
+                    auto safe_consumers = getSafeConsumers();
+                    for (auto const & consumer_ptr : safe_consumers.consumers)
+                        consumer_ptr->setExceptionInfo(*err, false);
                     break;
+                }
 
                 LOG_DEBUG(log, "Started streaming to {} attached views", num_views);
 

--- a/src/Storages/Kafka/StorageKafkaUtils.h
+++ b/src/Storages/Kafka/StorageKafkaUtils.h
@@ -6,9 +6,11 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/StorageID.h>
 #include <base/types.h>
+#include <optional>
 #include <cppkafka/configuration.h>
 #include <cppkafka/cppkafka.h>
 #include <cppkafka/topic_partition.h>
+#include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <librdkafka/rdkafka.h>
 #include <Common/SettingsChanges.h>
@@ -57,7 +59,7 @@ size_t eraseMessageErrors(Messages & messages, const LoggerPtr & log, ErrorHandl
 
 SettingsChanges createSettingsAdjustments(KafkaSettings & kafka_settings, const String & schema_name);
 
-bool checkDependencies(const StorageID & table_id, const ContextPtr& context);
+std::optional<String> checkDependencies(const StorageID & table_id, const ContextPtr & context);
 
 VirtualColumnsDescription createVirtuals(StreamingHandleErrorMode handle_error_mode);
 }

--- a/tests/integration/test_storage_kafka/test_mv_target_missing.py
+++ b/tests/integration/test_storage_kafka/test_mv_target_missing.py
@@ -1,0 +1,108 @@
+import logging
+import time
+
+import pytest
+from kafka import KafkaAdminClient
+
+from helpers.cluster import ClickHouseCluster
+import helpers.kafka.common as k
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance(
+    "instance",
+    main_configs=["configs/kafka.xml", "configs/named_collection.xml"],
+    user_configs=["configs/users.xml"],
+    with_kafka=True,
+    with_zookeeper=True,
+    macros={
+        "kafka_broker": "kafka1",
+        "kafka_topic_old": "old",
+        "kafka_group_name_old": "old",
+        "kafka_topic_new": "new",
+        "kafka_group_name_new": "new",
+        "kafka_client_id": "instance",
+        "kafka_format_json_each_row": "JSONEachRow",
+    },
+    clickhouse_path_dir="clickhouse_path",
+)
+
+
+@pytest.fixture(scope="module")
+def kafka_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def kafka_setup_teardown():
+    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
+    admin_client = k.get_admin_client(cluster)
+    topics = [t for t in admin_client.list_topics() if not t.startswith("_")]
+    if topics:
+        admin_client.delete_topics(topics)
+    yield
+
+
+def test_missing_mv_target(kafka_cluster):
+    admin = k.get_admin_client(kafka_cluster)
+    topic = "mv_target_missing"
+    k.kafka_create_topic(admin, topic)
+
+    instance.query(
+        f"""
+        DROP TABLE IF EXISTS test.kafka;
+        DROP TABLE IF EXISTS test.target1;
+        DROP TABLE IF EXISTS test.target2;
+        DROP TABLE IF EXISTS test.mv1;
+        DROP TABLE IF EXISTS test.mv2;
+
+        CREATE TABLE test.kafka (a UInt64, b String)
+            ENGINE = Kafka
+            SETTINGS kafka_broker_list = 'kafka1:19092',
+                     kafka_topic_list = '{topic}',
+                     kafka_group_name = '{topic}',
+                     kafka_commit_on_select = 1,
+                     kafka_format = 'CSV',
+                     kafka_row_delimiter = '\n',
+                     format_csv_delimiter = '|';
+
+        CREATE TABLE test.target2 (a UInt64, b String) ENGINE = MergeTree() ORDER BY a;
+        CREATE MATERIALIZED VIEW test.mv1 TO test.target1 AS SELECT * FROM test.kafka;
+        CREATE MATERIALIZED VIEW test.mv2 TO test.target2 AS SELECT * FROM test.kafka;
+        """
+    )
+
+    def has_error(res):
+        return "Materialized view" in res
+
+    instance.query_with_retry(
+        "SELECT exceptions.text[1] FROM system.kafka_consumers WHERE database='test' and table='kafka'",
+        check_callback=has_error,
+    )
+
+    instance.query("CREATE TABLE test.target1 (a UInt64, b String) ENGINE = MergeTree() ORDER BY a")
+
+    k.kafka_produce(kafka_cluster, topic, ["1|foo", "2|bar"])
+
+    assert instance.query_with_retry(
+        "SELECT count() FROM test.target2",
+        check_callback=lambda x: int(x) == 2,
+    ).strip() == "2"
+    assert instance.query_with_retry(
+        "SELECT count() FROM test.target1",
+        check_callback=lambda x: int(x) == 2,
+    ).strip() == "2"
+
+    instance.query(
+        """
+        DROP TABLE test.mv1;
+        DROP TABLE test.mv2;
+        DROP TABLE test.target1;
+        DROP TABLE test.target2;
+        DROP TABLE test.kafka;
+        """
+    )
+    k.kafka_delete_topic(admin, topic)


### PR DESCRIPTION
## Summary
- report missing materialized view target tables for Kafka tables
- expose the error through `system.kafka_consumers`
- add integration test covering this scenario

## Testing
- `pytest -q tests/integration/test_storage_kafka/test_mv_target_missing.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_685b14ca56848323834460f201b10a92